### PR TITLE
Pinning omniauth-auth2 version to 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.3.1 (2015-11-19)
+ * Pinned version of omniauth-auth2 to 1.3.1 since 1.4.0 removes a `callback_url`
+   method required for the Auth Workflow.
+   Expecting to be fixed by https://github.com/doorkeeper-gem/doorkeeper/issues/737
+
 ## v0.3.0 (2015-06-01)
 
 * Added resource type and urn to roles

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is the [OmniAuth][omniauth] strategy for authenticating to G5 via
 
 ## Current version
 
-0.3.0
+0.3.1
 
 ## Requirements
 

--- a/lib/omniauth-g5/version.rb
+++ b/lib/omniauth-g5/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module G5
-    VERSION = '0.3.0'
+    VERSION = '0.3.1'
   end
 end

--- a/omniauth-g5.gemspec
+++ b/omniauth-g5.gemspec
@@ -17,7 +17,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency('omniauth-oauth2', '~> 1.1')
+  # Pinning version to 1.3.1 since 1.4.0 removes the `callback_url` mehtod required for our oauth workflow
+  gem.add_dependency('omniauth-oauth2', '= 1.3.1')
 
   gem.add_development_dependency('rspec', '~> 3.2')
   gem.add_development_dependency('rspec-its')

--- a/omniauth-g5.gemspec
+++ b/omniauth-g5.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  # Pinning version to 1.3.1 since 1.4.0 removes the `callback_url` mehtod required for our oauth workflow
+  # Pinning version to 1.3.1 since 1.4.0 removes the `callback_url` method required for our oauth workflow
   gem.add_dependency('omniauth-oauth2', '= 1.3.1')
 
   gem.add_development_dependency('rspec', '~> 3.2')


### PR DESCRIPTION
Pinning omniauth-auth2 version to 1.3.1 since 1.4.1 introduces a change that removes `callback_url` method required for our Auth Workflow

https://github.com/intridea/omniauth-oauth2/pull/70
- Pinning in the mean time doorkeeper fixes it (https://github.com/doorkeeper-gem/doorkeeper/issues/737 )

[Fixes #108467542]
